### PR TITLE
docs(tutorials): remove --recursive

### DIFF
--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -34,7 +34,7 @@ Please execute the following steps on Ubuntu 20.04. The order is important so th
 
    ```bash
    mkdir src
-   vcs import src < caret.repos --recursive
+   vcs import src < caret.repos
    ```
 
 3. Run `setup_caret.sh`.


### PR DESCRIPTION
Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>

In tutorial chapter, `--recursive` option is no longer necessary for executing `vcs import`. 
This PR is related  with  https://github.com/tier4/CARET_analyze_cpp_impl/pull/17/files .