### PR TITLE
fix(tutorial): modify path name corresponding to the sample architecture file.

### DIFF
--- a/docs/tutorials/visualization.md
+++ b/docs/tutorials/visualization.md
@@ -74,7 +74,7 @@ Execute the following code for visualization with message flow.
 ```python
 from caret_analyze.plot import message_flow
 
-path = app.get_path('target_path')
+path = app.get_path('target')
 message_flow(path)
 ```
 


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

sample architecture file defines a path with "target".

https://raw.githubusercontent.com/tier4/CARET_demos/main/samples/end_to_end_sample/architecture.yaml