### PR TITLE
docs(design): add description for construction_order

### DIFF
--- a/docs/design/configuration/architecture_file.md
+++ b/docs/design/configuration/architecture_file.md
@@ -109,7 +109,7 @@ nodes:
 
 ## Callback identification
 
-It's convenience for users to give a name to a callback function for its identification. However, in the context of ROS 2, only an address is given to  a callback.
+It's convenience for users to give a name to a callback function for its identification. However, in the context of ROS 2, only an address is given to a callback.
 
 CARET helps users to give a name to a callback, but it is not directly associated with its address due to the reason as explained above.
 

--- a/docs/design/configuration/architecture_file.md
+++ b/docs/design/configuration/architecture_file.md
@@ -107,7 +107,7 @@ nodes:
         publisher_topic_name: /ping
 ```
 
-## Callback identifiation
+## Callback identification
 
 `callback_name` is a name used by users to identify a callback.
 

--- a/docs/design/configuration/architecture_file.md
+++ b/docs/design/configuration/architecture_file.md
@@ -109,7 +109,7 @@ nodes:
 
 ## Callback identification
 
-It's convenience for users to give a name to a callback function for its identification. However, in the context of ROS 2, only an address is given to a callback.
+It's convenient for users to give a name to a callback function for its identification. However, in the context of ROS 2, only an address is given to a callback.
 
 Addresses change with each launch of an application.
 This makes it difficult to handle callbacks by address when evaluating performance of them.
@@ -126,4 +126,4 @@ In order to tackle the issue, CARET associates a name with an address of callbac
 - `construction_order`
 
 By using this information to match `callback_name` and callback address,
-each `callback_name` will always refer to identical callbacks without regarding to callback address.
+each `callback_name` will always refer to identical callbacks without being aware of callback address.

--- a/docs/design/configuration/architecture_file.md
+++ b/docs/design/configuration/architecture_file.md
@@ -35,6 +35,7 @@ A sample of the architecture file is as follows.
 | &emsp; &emsp; symbol                  | String       | Yes                                        | Yes                                        | symbol for callback function.                      |
 | &emsp; &emsp; period_ns               | int          | Required for timer_callback only.          | Yes                                        |                                                    |
 | &emsp; &emsp; topic_name              | String       | Required for subscription_callback only.   | Yes                                        |                                                    |
+| &emsp; &emsp; construction_order      | int          | No                                         | No                                         | Zero is used as the default value if not present.  |
 | &emsp; variable_passings              | List         | No                                         | Yes                                        |                                                    |
 | &emsp; &emsp; callback_name_write     | String       | No                                         | No (Edit architecture file)                | default value = UNDEFINED                          |
 | &emsp; &emsp; callback_name_read      | String       | No                                         | No (Edit architecture file)                | default value = UNDEFINED                          |
@@ -85,6 +86,11 @@ nodes:
         type: timer_callback
         period_ns: 100000000
         symbol: Node::{lambda()}
+      - callback_name: timer_callback_0
+        type: timer_callback
+        period_ns: 100000000
+        symbol: Node::{lambda()}
+        construction_order: 1
     variable_passings:
       - callback_name_write: subscription_callback_0
         callback_name_read: timer_callback_0
@@ -100,3 +106,22 @@ nodes:
         subscription_topic_name: /pong
         publisher_topic_name: /ping
 ```
+
+## Callback identifiation
+
+`callback_name` is a name used by users to identify a callback.
+
+CARET reads trace data and loads callback information.
+Callback addresses can be obtained from trace data,
+but callback_name cannot be obtained because ROS does not have the ability to assign callback_names.
+
+After loading information, CARET binds the `callback_name` and callback address by following items.
+
+- node_name
+- callback_type
+- period_ns / topic_name
+- symbol
+- construction_order
+
+By using this information to match `callback_name` and callback address,
+`callback_name` will always refer to identical callbacks, regardless of the number of recordings.

--- a/docs/design/configuration/architecture_file.md
+++ b/docs/design/configuration/architecture_file.md
@@ -111,6 +111,10 @@ nodes:
 
 It's convenience for users to give a name to a callback function for its identification. However, in the context of ROS 2, only an address is given to a callback.
 
+Addresses change with each launch of an application.
+This makes it difficult to handle callbacks by address when evaluating performance of them.
+For example, if you want to compare the execution time of a particular callback for each launch, you have to find address to select target callbacks.
+
 CARET helps users to give a name to a callback, but it is not directly associated with its address due to the reason as explained above.
 
 In order to tackle the issue, CARET associates a name with an address of callback with using combination of following data.
@@ -122,4 +126,4 @@ In order to tackle the issue, CARET associates a name with an address of callbac
 - `construction_order`
 
 By using this information to match `callback_name` and callback address,
-`callback_name` will always refer to identical callbacks, regardless of the number of recordings.
+each `callback_name` will always refer to identical callbacks without regarding to callback address.

--- a/docs/design/configuration/architecture_file.md
+++ b/docs/design/configuration/architecture_file.md
@@ -109,19 +109,17 @@ nodes:
 
 ## Callback identification
 
-`callback_name` is a name used by users to identify a callback.
+It's convenience for users to give a name to a callback function for its identification. However, in the context of ROS 2, only an address is given to  a callback.
 
-CARET reads trace data and loads callback information.
-Callback addresses can be obtained from trace data,
-but callback_name cannot be obtained because ROS does not have the ability to assign callback_names.
+CARET helps users to give a name to a callback, but it is not directly associated with its address due to the reason as explained above.
 
-After loading information, CARET binds the `callback_name` and callback address by following items.
+In order to tackle the issue, CARET associates a name with an address of callback with using combination of following data.
 
-- node_name
-- callback_type
-- period_ns / topic_name
-- symbol
-- construction_order
+- `node_name`
+- `callback_type`
+- `period_ns` / `topic_name`
+- `symbol`
+- `construction_order`
 
 By using this information to match `callback_name` and callback address,
 `callback_name` will always refer to identical callbacks, regardless of the number of recordings.


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

## Description

This PR adds description for construction_order in architecture file.

## Related links

Implemented in :
https://github.com/tier4/CARET_analyze/pull/225

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
