### PR TITLE
fix: caret_light event filter

### DIFF
--- a/docs/recording/recording.md
+++ b/docs/recording/recording.md
@@ -185,7 +185,8 @@ def generate_launch_description():
             "ros2_caret:*executor",
             "ros2_caret:dds_bind*",
             "ros2:rcl_*init",
-            "ros2_caret:rcl_*init"]
+            "ros2_caret:rcl_*init",
+            "ros2_caret:caret_init"]
 
   if caret_session == "":
     dt_now = datetime.datetime.now()


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

Add `ros2_caret:caret_init` to caret_light event filter. Without it, some visualization (like path analysis) doesn't work.

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/T4PB-24857)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
