### PR TITLE
fix: lack of import in quick start

### DIFF
--- a/docs/visualization/index.md
+++ b/docs/visualization/index.md
@@ -7,6 +7,7 @@ This chapter explains how to visualize trace data as you expect. [Gallery](../ga
 CARET serves `Plot` class to visualize trace data. The following sample code shows the basic usage of `Plot`.
 
 ```python
+from caret_analyze import Application, Architecture, Lttng
 from caret_analyze.plot import Plot
 from bokeh.plotting import output_notebook, figure, show
 output_notebook()


### PR DESCRIPTION
Signed-off-by: rokamu623 <r.okamura.061@ms.saitama-u.ac.jp>

## Description
The use case listed on this page is missing imports for some packages.

If you run the use case as is, it will return an error due to missing package imports.

current
```
from caret_analyze.plot import Plot
from bokeh.plotting import output_notebook, figure, show
```

expected
```
from caret_analyze import Application, Architecture, Lttng
from caret_analyze.plot import Plot
from bokeh.plotting import output_notebook, figure, show
```

<!-- Write a brief description of this PR. -->

## Related links
[CARET_doc/Visualization](https://tier4.github.io/CARET_doc/latest/visualization/)

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
