### PR TITLE
docs(configuration): add the explanation of Architecture.diff_* functions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 ## CARET
 
+### v0.4.4 <small>\_ Feb 21, 2022</small> {id = "0.4.4"}
+
+- Fixed the time format of the time-series graphs ([CARET_analyze #255](https://github.com/tier4/CARET_analyze/pull/255))
+- Added the design documentation for trace filtering to exclude events in DDS-layer ([CARET_doc #158](https://github.com/tier4/CARET_doc/pull/158))
+- Moved `get_range()` function to `record` package ([CARET_analyze #254](https://github.com/tier4/CARET_analyze/pull/254))
+
 ### v0.4.3 <small>\_ Feb 10, 2022</small> {id = "0.4.3"}
 
 - Fixed the bug preventing `check_ctf` from running properly after supporting activation/deactivation on runtime ([CARET_analyze #251](https://github.com/tier4/CARET_analyze/pull/251))

--- a/docs/configuration/.pages
+++ b/docs/configuration/.pages
@@ -6,3 +6,4 @@ nav:
     - Define intra-node data path: intra_node_data_path.md
     - Practical example: practical_example.md
     - Visualize application structure: visualize_application_structure.md
+    - Require differences: architecture_diff_func.md 

--- a/docs/configuration/.pages
+++ b/docs/configuration/.pages
@@ -7,4 +7,4 @@ nav:
     - Rename sub-objects: rename_function.md
     - Practical example: practical_example.md
     - Visualize application structure: visualize_application_structure.md
-    - Require differences: architecture_diff_func.md 
+    - Differences of architectures: architecture_diff_func.md 

--- a/docs/configuration/.pages
+++ b/docs/configuration/.pages
@@ -5,7 +5,7 @@ nav:
     - Define inter-node data path: inter_node_data_path.md
     - Define intra-node data path: intra_node_data_path.md
     - Rename sub-objects: rename_function.md
-    - Get difference between two architecture objects: architecture_diff_func.md 
+    - Get difference between two architecture objects: architecture_diff_func.md
     - Practical example: practical_example.md
     - Visualize application structure: visualize_application_structure.md
-    
+

--- a/docs/configuration/.pages
+++ b/docs/configuration/.pages
@@ -8,4 +8,3 @@ nav:
     - Get difference between two architecture objects: architecture_diff_func.md
     - Practical example: practical_example.md
     - Visualize application structure: visualize_application_structure.md
-

--- a/docs/configuration/.pages
+++ b/docs/configuration/.pages
@@ -5,6 +5,7 @@ nav:
     - Define inter-node data path: inter_node_data_path.md
     - Define intra-node data path: intra_node_data_path.md
     - Rename sub-objects: rename_function.md
+    - Get difference between two architecture objects: architecture_diff_func.md 
     - Practical example: practical_example.md
     - Visualize application structure: visualize_application_structure.md
-    - Differences of architectures: architecture_diff_func.md 
+    

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -1,13 +1,14 @@
-# Require differences of two architectures 
+# Differences of architectures
 
 The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that only exist in each, e.g. node name, pub/sub topic.
-There are five diff functions, which can be divided into functions that compare the entire architecture and functions that compare nodes within the architecture. `diff_node_names()`, `diff_topic_names` are functions that take two architectures and compare them as a whole. The two functions compare all node names in the architecture for the former and all pub/sub topic names in the architecture for the latter.
+There are four diff functions, which can be divided into functions that compare the entire architecture and functions that compare nodes within the architecture.
+ <!-- `diff_node_names()`, `diff_topic_names` are functions that take two architectures and compare them as a whole. The two functions compare all node names in the architecture for the former and all pub/sub topic names in the architecture for the latter.
 
-`diff_node_pubs()`, `diff_node_subs()` and `diff_node_callbacks()` are functions that compare two nodes within an architecture. These are functions that compare two given nodes and return the publish topic name, subscribe topic name, or callback name that is only in each.
+`diff_node_pubs()`, `diff_node_subs()` and `diff_node_callbacks()` are functions that compare two nodes within an architecture. These are functions that compare two given nodes and return the publish topic name, subscribe topic name, or callback name that is only in each. -->
 
-## How to use diff functions to compare architecure
+## How to compare architecture
 
-In CARET, the structure of the target application is described in an architecture file. The actual architecure file can be represented as an object of Architecture class. This section describes the functions `diff_node_names()` and `diff_topic_names()`, which compare the contents of two architecture objects.
+In CARET, the structure of the target application is described in an architecture file. The actual architecture file can be represented as an object of Architecture class. This section describes the functions `diff_node_names()` and `diff_topic_names()`, which compare the contents of two architecture objects.
 One possible use of these functions is to check the changes between the architecture before and after changes.
 
 ### diff_node_names()
@@ -70,9 +71,9 @@ print(new_only_topics)
 
 ```
 
-## How to use diff functions to compare node in architecure
+## How to compare node in architecture
 
-This section describes the functions `diff_node_pubs()`, `diff_node_subs()`, and `diff_node_callbacks()`, which compare the contents of two nodes in architecture.
+This section describes the functions `diff_node_pubs()` and `diff_node_subs()`, which compare the contents of two nodes in architecture.
 
 ### diff_node_pubs()
 
@@ -133,5 +134,3 @@ print(new_only_subscribe_topics)
 #('topic3', 'topic4')
 
 ```
-
-### diff_node_callbacks()

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -86,7 +86,6 @@ print(right_only_pub_topics)
 
 Two nodes, whose types are `NodeStructValue`, are given to `diff_node_pubs()`. Two tuples containing topic names are returned if they have any different published topics. If they are have the same topics at all, `diff_node_pubs()` returns two empty tuples.
 
-
 ### diff_node_subs()
 
 The `diff_node_subs()` function returns the name of the subscribed topic whose name appears only in one of the two nodes.

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -8,62 +8,54 @@ There are four diff functions, which can be divided into functions that compare 
 
 ## How to compare architecture
 
-In CARET, the structure of the target application is described in an architecture file. The actual architecture file can be represented as an object of Architecture class. This section describes the functions `diff_node_names()` and `diff_topic_names()`, which compare the contents of two architecture objects.
+In CARET, the structure of the target application is described in an architecture file. The actual architecture file can be represented as an object of Architecture class. This section describes the functions `diff_node_names()` and `diff_topic_names()`, which compare the contents of two architecture objects. In `diff_node_names()` and `diff_topic_names()`, the functions compare two architectures and return the node or topic names that only each has. Therefore, by using these functions, what one ARCHITECTURE has but the other does not (node names or topic names) are clear and can be compared.
 One possible use of these functions is to check the changes between the architecture before and after changes.
+
+The diff function is explained below, and before using the diff functions, the two architecture objects are generated beforehand, as shown in the following script.
+
+```python
+from caret_analyze import Architecture
+left_arch = Architecture('yaml', 'old_architecture.yaml')
+right_arch = Architecture('yaml', 'new_architecture.yaml')
+
+```
 
 ### diff_node_names()
 An example of the use of `diff_node_names()` is shown in `#sample_1`.
-Suppose arch1 has two nodes 'node1' and 'node2'. arch2 has three nodes 'node1', 'node3' and 'node4'. 
-The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
+<!-- Suppose arch1 has two nodes 'node1' and 'node2'. arch2 has three nodes 'node1', 'node3' and 'node4'. 
+The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]` -->
 
 
 ```python
 #sample_1
 
-from caret_analyze import Architecture
-
-#arch1 has two nodes: 'node1' and 'node2'.
-arch1 = Architecture('yaml', 'old_architecture.yaml')
-
-#arch2 has three nodes: 'node1', 'node3', and 'node4'
-arch2 = Architecture('yaml', 'new_architecture.yaml')
-
 #get node names that are only in old and new respectively.
-old_only_node_names, new_only_node_names = \
-            Architecture.diff_node_names(arch1, arch2)
+left_only_node_names, right_only_node_names = Architecture.diff_node_names(left_arch, right_arch)
 
-print(old_only_node_names)
-print(new_only_node_names)
+print(left_only_node_names)
+print(right_only_node_names)
 
 #result
 #('node2',)
 #('node3', 'node4')
 
-
 ```
+
+In this setup, the `left_arch` has two nodes: `node1` and `node2`, and the `right_arch` has three nodes: `node1`, `node3` and `node4`. Therefore, the node name that `left_arch` and `right_arch` have in common is `node1`.
+Therefore, the node name that only `left_arch` has is `node2`, and the node names that only `right_arch` has are `node3` and `node4`, which are the return value and output at the end of the script respectively.
 
 ### diff_topic_names()
 
 An example of the use of `diff_topic_names()` is shown in `#sample_2`.
-Suppose arch1 has two pub/sub topics: 'topic1' and 'topic2'. arch2 has three pub/sub topics: 'topi1c', 'topic3' and 'topic4'. The pub/sub topic here is the topic used in publish or subscribe.
-The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
 
 ```python
 #sample_2
 
-from caret_analyze import Architecture
-
-#arch1 has two pub/sub topics: 'topic1' and 'topic2'.
-arch1 = Architecture('yaml', 'old_architecture.yaml')
-
-#arch2 has three pub/sub topics: 'topic1', 'topic3', and 'topic4'
-arch2 = Architecture('yaml', 'new_architecture.yaml')
-
 #get topic names that are only in old and new respectively.
-old_only_topics, new_only_topics = Architecture.diff_topic_names(arch1, arch2)
+left_only_topics, right_only_topics = Architecture.diff_topic_names(left_arch, right_arch)
 
-print(old_only_topics)
-print(new_only_topics)
+print(left_only_topics)
+print(right_only_topics)
 
 #result
 #('topic2',)
@@ -71,66 +63,62 @@ print(new_only_topics)
 
 ```
 
+In this setup, the `left_arch` has two topic names: `topic1` and `topic2`, and the `right_arch` has three topic names: `topic1`, `topic3` and `topic4`. The topic name here is the name of the topic used for publish or subscribe.　Therefore, the topic name that `left_arch` and `right_arch` have in common is `topic1`.
+Therefore, the topic name that only `left_arch` has is `topic2`, and the topic names that only `right_arch` has are `topic3` and `topic4`, which are the return value and output at the end of the script respectively.
+
 ## How to compare node in architecture
 
-This section describes the functions `diff_node_pubs()` and `diff_node_subs()`, which compare the contents of two nodes in architecture.
+<!-- This section describes the functions `diff_node_pubs()` and `diff_node_subs()`, which compare the contents of two nodes in architecture. -->
+`diff_node_pubs()` and `diff_node_subs()` are functions that take nodes in an architecture and compare them. The nodes given can be two nodes in the same architecture or in two different architectures. These functions compare the two given nodes and find the pub/sub topic name that exists only in each of them. Thus, what one node has but the other does not (pub/sub topic name) can be identified and compared.
 
 ### diff_node_pubs()
 
 An example of the use of `diff_node_pubs()` is shown in `#sample_3`.
-Suppose arch1 has two publish topics: 'topic1' and 'topic2'. arch2 has three publish topics: 'topic1', 'topic3' and 'topic4'. 
-The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
 
 ```python
 #sample_3
 
-from caret_analyze import Architecture
-
-#arch1 has two publish topics: 'topic1' and 'topic2'.
-arch1 = Architecture('yaml', 'old_architecture.yaml')
-
-#arch2 has three publish topics: 'topic1', 'topic3', and 'topic4'
-arch2 = Architecture('yaml', 'new_architecture.yaml')
+left_node = left_arch.nodes[0]
+right_node = right_arch.nodes[0]
 
 #get publish topic names that are only in old and new respectively.
-old_only_publish_topics, new_only_publish_topics = \
-                Architecture.diff_node_pubs(arch1, arch2)
+left_only_pub_topics, right_only_pub_topics = Architecture.diff_node_pubs(left_node, right_node)
 
-print(old_only_publish_topics)
-print(new_only_publish_topics)
+print(left_only_pub_topics)
+print(right_only_pub_topics)
 
 #result
+#('topic1',)
 #('topic2',)
-#('topic3', 'topic4')
 
 ```
+In this case, consider a comparison for the first node (with index 0) of `left_arch` and `right_arch`. In this case, the setup assumes that the `left_node` has `topic1` as the publish topic and the `right_node` has `topic2` as the publish topic.
+At this time, there is no common publish topic for both.
+Therefore, the publish topic that exists only in the `left_node` is `topic1` and the publish topic that exists only in the `right_node` is `topic2`.
+Therefore, these are returned as the names of the publish topics that exist only in each node and are output at the end of the script.
 
 ### diff_node_subs()
 
 An example of the use of `diff_node_subs()` is shown in `#sample_4`.
-Suppose arch1 has two subscribe topics: 'topic1' and 'topic2'. arch2 has three subscribe topics: 'topic1', 'topic3' and 'topic4'. 
-The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
 
 ```python
 #sample_4
 
-from caret_analyze import Architecture
+left_node = left_arch.nodes[0]
+right_node = right_arch.nodes[0]
 
-#arch1 has two subscribe topics: 'topic1' and 'topic2'.
-arch1 = Architecture('yaml', 'old_architecture.yaml')
+#get publish topic names that are only in old and new respectively.
+left_only_pub_topics, right_only_pub_topics = Architecture.diff_node_subs(left_node, right_node)
 
-#arch2 has three subscribe topics: 'topic1', 'topic3', and 'topic4'
-arch2 = Architecture('yaml', 'new_architecture.yaml')
-
-#get subscribe topic names that are only in old and new respectively.
-old_only_subscribe_topics, new_only_subscribe_topics = \
-                    Architecture.diff_node_subs(arch1, arch2)
-
-print(old_only_subscribe_topics)
-print(new_only_subscribe_topics)
+print(left_only_sub_topics)
+print(right_only_sub_topics)
 
 #result
+#('topic1',)
 #('topic2',)
-#('topic3', 'topic4')
 
 ```
+In this case, consider a comparison for the first node (with index 0) of `left_arch` and `right_arch`. In this case, the setup assumes that the `left_node` has `topic1` as the subscribe topic and the `right_node` has `topic2` as the subscribe topic.
+At this time, there is no common subscribe topic for both.
+Therefore, the subscribe topic that exists only in the `left_node` is `topic1` and the subscribe topic that exists only in the `right_node` is `topic2`.
+Therefore, these are returned as the names of the subscribe topics that exist only in each node and are output at the end of the script.

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -25,12 +25,12 @@ If there are no return values, it means that the two architecture objects repres
 The function `diff_node_names()` compares node names of architectures.
 
 ```python
-#sample_1
+# sample_1
 
-#get node names that are only in left_arch and right_arch respectively
+# get node names that are only in left_arch and right_arch respectively
 left_only_node_names, right_only_node_names = Architecture.diff_node_names(left_arch, right_arch)
 
-#display differences
+# display differences
 print(left_only_node_names)
 print(right_only_node_names)
 
@@ -43,12 +43,12 @@ This function inputs two architectures, compares them, and outputs the node name
 The function `diff_topic_names()` compares pub/sub topic names of architectures.
 
 ```python
-#sample_2
+# sample_2
 
-#get topic names that are only in left_arch and right_arch respectively
+# get topic names that are only in left_arch and right_arch respectively
 left_only_topics, right_only_topics = Architecture.diff_topic_names(left_arch, right_arch)
 
-#display differences
+# display differences
 print(left_only_topics)
 print(right_only_topics)
 
@@ -66,15 +66,15 @@ This function inputs two architectures, compares them, and outputs the pub/sub t
 The function `diff_node_pubs()` compares publish topic names of nodes of architectures.
 
 ```python
-#sample_3
+# sample_3
 
 left_node = left_arch.get_node('node1')
 right_node = right_arch.get_node('node1')
 
-#get publish topic names that are only in left_node and right_node respectively
+# get publish topic names that are only in left_node and right_node respectively
 left_only_pub_topics, right_only_pub_topics = Architecture.diff_node_pubs(left_node, right_node)
 
-#display differences
+# display differences
 print(left_only_pub_topics)
 print(right_only_pub_topics)
 
@@ -86,15 +86,15 @@ This function inputs two nodes of architectures, compares them, and outputs the 
 The function `diff_node_subs()` compares subscribe topic names of nodes of architectures.
 
 ```python
-#sample_4
+# sample_4
 
 left_node = left_arch.get_node('node1')
 right_node = right_arch.get_node('node1')
 
-#get subscribe topic names that are only in left_node and right_node respectively
+# get subscribe topic names that are only in left_node and right_node respectively
 left_only_sub_topics, right_only_sub_topics = Architecture.diff_node_subs(left_node, right_node)
 
-#display differences
+# display differences
 print(left_only_sub_topics)
 print(right_only_sub_topics)
 

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -1,4 +1,4 @@
-# Differences of architectures
+# How to get differences of architectures
 
 The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that only exist in each, e.g. node name, pub/sub topic.
 There are four diff functions, which can be divided into functions that compare the entire architecture and functions that compare nodes within the architecture.
@@ -15,9 +15,9 @@ right_arch = Architecture('yaml', 'new_architecture.yaml')
 
 ## How to compare architecture
 
-Architecture objects are generated from architecture files or trace data and summarize the structure of target applications.
 The functions `diff_node_names()` and `diff_topic_names()` compare two architecture objects by finding the node names and topic names that exist only in one of the two objects. 
-If there are no return values, it means that the two architecture objects represent the same architecture.
+One possible use of these functions is to check the changes between the architecture before and after changes.
+
 
 
 
@@ -56,10 +56,17 @@ print(right_only_topics)
 
 This function inputs two architectures, compares them, and outputs the pub/sub topic names that exist only in one of architectures.
 
+<prettier-ignore-start>
+!!!info
+      The architecture object has other elements such as Executor and Callback. However, the functions that gets the difference of Executors or Callbacks are not yet implemented. Please contact the developers if needed.
+<prettier-ignore-end>
+
+
 ## How to compare node in architecture
 
 
-`diff_node_pubs()` and `diff_node_subs()` are functions that take nodes in an architecture and compare them. The nodes given can be two nodes in the same architecture or in two different architectures. These functions compare the two given nodes and find the pub/sub topic name that exists only in each of them. Thus, what one node has but the other does not (pub/sub topic name) can be identified and compared.
+The `diff_node_pubs()` and `diff_node_subs()` function find the publish and subscription topics that exist only in one of the two nodes. 
+This function can be compare also two nodes in different architecture objects.
 
 ### diff_node_pubs()
 

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -1,6 +1,6 @@
 # How to get differences of architectures
 
-The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that only exist in each, e.g. node name, pub/sub topic.
+The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that exist only in one of the architectures, such as node names, publish/subscribe topics, etc. 
 There are four diff functions, which can be divided into functions that compare the entire architecture and functions that compare nodes within the architecture.
 
 The diff function is explained below, and before using the diff functions, the two architecture objects are generated beforehand, as shown in the following script.
@@ -58,7 +58,7 @@ This function inputs two architectures, compares them, and outputs the pub/sub t
 
 <prettier-ignore-start>
 !!!info
-      The architecture object has other elements such as Executor and Callback. However, the functions that gets the difference of Executors or Callbacks are not yet implemented. Please contact the developers if needed.
+      The architecture object has other elements such as Executor and Callback. However, the functions that get the difference of Executors or Callbacks are not yet implemented. Please contact the developers if needed.
 <prettier-ignore-end>
 
 

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -1,0 +1,137 @@
+# Require differences of two architectures 
+
+The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that only exist in each, e.g. node name, pub/sub topic.
+There are five diff functions, which can be divided into functions that compare the entire architecture and functions that compare nodes within the architecture. `diff_node_names()`, `diff_topic_names` are functions that take two architectures and compare them as a whole. The two functions compare all node names in the architecture for the former and all pub/sub topic names in the architecture for the latter.
+
+`diff_node_pubs()`, `diff_node_subs()` and `diff_node_callbacks()` are functions that compare two nodes within an architecture. These are functions that compare two given nodes and return the publish topic name, subscribe topic name, or callback name that is only in each.
+
+## How to use diff functions to compare architecure
+
+In CARET, the structure of the target application is described in an architecture file. The actual architecure file can be represented as an object of Architecture class. This section describes the functions `diff_node_names()` and `diff_topic_names()`, which compare the contents of two architecture objects.
+One possible use of these functions is to check the changes between the architecture before and after changes.
+
+### diff_node_names()
+An example of the use of `diff_node_names()` is shown in `#sample_1`.
+Suppose arch1 has two nodes 'node1' and 'node2'. arch2 has three nodes 'node1', 'node3' and 'node4'. 
+The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
+
+
+```python
+#sample_1
+
+from caret_analyze import Architecture
+
+#arch1 has two nodes: 'node1' and 'node2'.
+arch1 = Architecture('yaml', 'old_architecture.yaml')
+
+#arch2 has three nodes: 'node1', 'node3', and 'node4'
+arch2 = Architecture('yaml', 'new_architecture.yaml')
+
+#get node names that are only in old and new respectively.
+old_only_node_names, new_only_node_names = \
+            Architecture.diff_node_names(arch1, arch2)
+
+print(old_only_node_names)
+print(new_only_node_names)
+
+#result
+#('node2',)
+#('node3', 'node4')
+
+
+```
+
+### diff_topic_names()
+
+An example of the use of `diff_topic_names()` is shown in `#sample_2`.
+Suppose arch1 has two pub/sub topics: 'topic1' and 'topic2'. arch2 has three pub/sub topics: 'topi1c', 'topic3' and 'topic4'. The pub/sub topic here is the topic used in publish or subscribe.
+The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
+
+```python
+#sample_2
+
+from caret_analyze import Architecture
+
+#arch1 has two pub/sub topics: 'topic1' and 'topic2'.
+arch1 = Architecture('yaml', 'old_architecture.yaml')
+
+#arch2 has three pub/sub topics: 'topic1', 'topic3', and 'topic4'
+arch2 = Architecture('yaml', 'new_architecture.yaml')
+
+#get topic names that are only in old and new respectively.
+old_only_topics, new_only_topics = Architecture.diff_topic_names(arch1, arch2)
+
+print(old_only_topics)
+print(new_only_topics)
+
+#result
+#('topic2',)
+#('topic3', 'topic4')
+
+```
+
+## How to use diff functions to compare node in architecure
+
+This section describes the functions `diff_node_pubs()`, `diff_node_subs()`, and `diff_node_callbacks()`, which compare the contents of two nodes in architecture.
+
+### diff_node_pubs()
+
+An example of the use of `diff_node_pubs()` is shown in `#sample_3`.
+Suppose arch1 has two publish topics: 'topic1' and 'topic2'. arch2 has three publish topics: 'topic1', 'topic3' and 'topic4'. 
+The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
+
+```python
+#sample_3
+
+from caret_analyze import Architecture
+
+#arch1 has two publish topics: 'topic1' and 'topic2'.
+arch1 = Architecture('yaml', 'old_architecture.yaml')
+
+#arch2 has three publish topics: 'topic1', 'topic3', and 'topic4'
+arch2 = Architecture('yaml', 'new_architecture.yaml')
+
+#get publish topic names that are only in old and new respectively.
+old_only_publish_topics, new_only_publish_topics = \
+                Architecture.diff_node_pubs(arch1, arch2)
+
+print(old_only_publish_topics)
+print(new_only_publish_topics)
+
+#result
+#('topic2',)
+#('topic3', 'topic4')
+
+```
+
+### diff_node_subs()
+
+An example of the use of `diff_node_subs()` is shown in `#sample_4`.
+Suppose arch1 has two subscribe topics: 'topic1' and 'topic2'. arch2 has three subscribe topics: 'topic1', 'topic3' and 'topic4'. 
+The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]`
+
+```python
+#sample_4
+
+from caret_analyze import Architecture
+
+#arch1 has two subscribe topics: 'topic1' and 'topic2'.
+arch1 = Architecture('yaml', 'old_architecture.yaml')
+
+#arch2 has three subscribe topics: 'topic1', 'topic3', and 'topic4'
+arch2 = Architecture('yaml', 'new_architecture.yaml')
+
+#get subscribe topic names that are only in old and new respectively.
+old_only_subscribe_topics, new_only_subscribe_topics = \
+                    Architecture.diff_node_subs(arch1, arch2)
+
+print(old_only_subscribe_topics)
+print(new_only_subscribe_topics)
+
+#result
+#('topic2',)
+#('topic3', 'topic4')
+
+```
+
+### diff_node_callbacks()

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -1,6 +1,6 @@
 # How to get differences of architectures
 
-The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that exist only in one of the architectures, such as node names, publish/subscribe topics, etc. 
+The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that exist only in one of the architectures, such as node names, publish/subscribe topics, etc.
 There are four diff functions, which can be divided into functions that compare the entire architecture and functions that compare nodes within the architecture.
 
 The diff function is explained below, and before using the diff functions, the two architecture objects are generated beforehand, as shown in the following script.
@@ -12,16 +12,13 @@ right_arch = Architecture('yaml', 'new_architecture.yaml')
 
 ```
 
-
 ## How to compare architecture
 
-The functions `diff_node_names()` and `diff_topic_names()` compare two architecture objects by finding the node names and topic names that exist only in one of the two objects. 
+The functions `diff_node_names()` and `diff_topic_names()` compare two architecture objects by finding the node names and topic names that exist only in one of the two objects.
 One possible use of these functions is to check the changes between the architecture before and after changes.
 
-
-
-
 ### diff_node_names()
+
 The function `diff_node_names()` compares node names of architectures.
 
 ```python
@@ -61,11 +58,9 @@ This function inputs two architectures, compares them, and outputs the pub/sub t
       The architecture object has other elements such as Executor and Callback. However, the functions that get the difference of Executors or Callbacks are not yet implemented. Please contact the developers if needed.
 <prettier-ignore-end>
 
-
 ## How to compare node in architecture
 
-
-The `diff_node_pubs()` and `diff_node_subs()` function find the publish and subscription topics that exist only in one of the two nodes. 
+The `diff_node_pubs()` and `diff_node_subs()` function find the publish and subscription topics that exist only in one of the two nodes.
 This function can be compare also two nodes in different architecture objects.
 
 ### diff_node_pubs()
@@ -86,6 +81,7 @@ print(left_only_pub_topics)
 print(right_only_pub_topics)
 
 ```
+
 This function inputs two nodes of architectures, compares them, and outputs the publish topic names that exist only in one of nodes.
 
 ### diff_node_subs()
@@ -106,4 +102,5 @@ print(left_only_sub_topics)
 print(right_only_sub_topics)
 
 ```
+
 This function inputs two nodes of architectures, compares them, and outputs the subscribe topic names that exist only in one of nodes.

--- a/docs/configuration/architecture_diff_func.md
+++ b/docs/configuration/architecture_diff_func.md
@@ -2,14 +2,6 @@
 
 The diff function can be used to find the difference between two architectures. Specifically, the diff functions can find data that only exist in each, e.g. node name, pub/sub topic.
 There are four diff functions, which can be divided into functions that compare the entire architecture and functions that compare nodes within the architecture.
- <!-- `diff_node_names()`, `diff_topic_names` are functions that take two architectures and compare them as a whole. The two functions compare all node names in the architecture for the former and all pub/sub topic names in the architecture for the latter.
-
-`diff_node_pubs()`, `diff_node_subs()` and `diff_node_callbacks()` are functions that compare two nodes within an architecture. These are functions that compare two given nodes and return the publish topic name, subscribe topic name, or callback name that is only in each. -->
-
-## How to compare architecture
-
-In CARET, the structure of the target application is described in an architecture file. The actual architecture file can be represented as an object of Architecture class. This section describes the functions `diff_node_names()` and `diff_topic_names()`, which compare the contents of two architecture objects. In `diff_node_names()` and `diff_topic_names()`, the functions compare two architectures and return the node or topic names that only each has. Therefore, by using these functions, what one ARCHITECTURE has but the other does not (node names or topic names) are clear and can be compared.
-One possible use of these functions is to check the changes between the architecture before and after changes.
 
 The diff function is explained below, and before using the diff functions, the two architecture objects are generated beforehand, as shown in the following script.
 
@@ -20,105 +12,91 @@ right_arch = Architecture('yaml', 'new_architecture.yaml')
 
 ```
 
-### diff_node_names()
-An example of the use of `diff_node_names()` is shown in `#sample_1`.
-<!-- Suppose arch1 has two nodes 'node1' and 'node2'. arch2 has three nodes 'node1', 'node3' and 'node4'. 
-The type of the return value is `Tuple[Tuple[str, ...] , Tuple[str, ...]]` -->
 
+## How to compare architecture
+
+Architecture objects are generated from architecture files or trace data and summarize the structure of target applications.
+The functions `diff_node_names()` and `diff_topic_names()` compare two architecture objects by finding the node names and topic names that exist only in one of the two objects. 
+If there are no return values, it means that the two architecture objects represent the same architecture.
+
+
+
+### diff_node_names()
+The function `diff_node_names()` compares node names of architectures.
 
 ```python
 #sample_1
 
-#get node names that are only in old and new respectively.
+#get node names that are only in left_arch and right_arch respectively
 left_only_node_names, right_only_node_names = Architecture.diff_node_names(left_arch, right_arch)
 
+#display differences
 print(left_only_node_names)
 print(right_only_node_names)
 
-#result
-#('node2',)
-#('node3', 'node4')
-
 ```
 
-In this setup, the `left_arch` has two nodes: `node1` and `node2`, and the `right_arch` has three nodes: `node1`, `node3` and `node4`. Therefore, the node name that `left_arch` and `right_arch` have in common is `node1`.
-Therefore, the node name that only `left_arch` has is `node2`, and the node names that only `right_arch` has are `node3` and `node4`, which are the return value and output at the end of the script respectively.
+This function inputs two architectures, compares them, and outputs the node names that exist only in one of architectures.
 
 ### diff_topic_names()
 
-An example of the use of `diff_topic_names()` is shown in `#sample_2`.
+The function `diff_topic_names()` compares pub/sub topic names of architectures.
 
 ```python
 #sample_2
 
-#get topic names that are only in old and new respectively.
+#get topic names that are only in left_arch and right_arch respectively
 left_only_topics, right_only_topics = Architecture.diff_topic_names(left_arch, right_arch)
 
+#display differences
 print(left_only_topics)
 print(right_only_topics)
 
-#result
-#('topic2',)
-#('topic3', 'topic4')
-
 ```
 
-In this setup, the `left_arch` has two topic names: `topic1` and `topic2`, and the `right_arch` has three topic names: `topic1`, `topic3` and `topic4`. The topic name here is the name of the topic used for publish or subscribe.　Therefore, the topic name that `left_arch` and `right_arch` have in common is `topic1`.
-Therefore, the topic name that only `left_arch` has is `topic2`, and the topic names that only `right_arch` has are `topic3` and `topic4`, which are the return value and output at the end of the script respectively.
+This function inputs two architectures, compares them, and outputs the pub/sub topic names that exist only in one of architectures.
 
 ## How to compare node in architecture
 
-<!-- This section describes the functions `diff_node_pubs()` and `diff_node_subs()`, which compare the contents of two nodes in architecture. -->
+
 `diff_node_pubs()` and `diff_node_subs()` are functions that take nodes in an architecture and compare them. The nodes given can be two nodes in the same architecture or in two different architectures. These functions compare the two given nodes and find the pub/sub topic name that exists only in each of them. Thus, what one node has but the other does not (pub/sub topic name) can be identified and compared.
 
 ### diff_node_pubs()
 
-An example of the use of `diff_node_pubs()` is shown in `#sample_3`.
+The function `diff_node_pubs()` compares publish topic names of nodes of architectures.
 
 ```python
 #sample_3
 
-left_node = left_arch.nodes[0]
-right_node = right_arch.nodes[0]
+left_node = left_arch.get_node('node1')
+right_node = right_arch.get_node('node1')
 
-#get publish topic names that are only in old and new respectively.
+#get publish topic names that are only in left_node and right_node respectively
 left_only_pub_topics, right_only_pub_topics = Architecture.diff_node_pubs(left_node, right_node)
 
+#display differences
 print(left_only_pub_topics)
 print(right_only_pub_topics)
 
-#result
-#('topic1',)
-#('topic2',)
-
 ```
-In this case, consider a comparison for the first node (with index 0) of `left_arch` and `right_arch`. In this case, the setup assumes that the `left_node` has `topic1` as the publish topic and the `right_node` has `topic2` as the publish topic.
-At this time, there is no common publish topic for both.
-Therefore, the publish topic that exists only in the `left_node` is `topic1` and the publish topic that exists only in the `right_node` is `topic2`.
-Therefore, these are returned as the names of the publish topics that exist only in each node and are output at the end of the script.
+This function inputs two nodes of architectures, compares them, and outputs the publish topic names that exist only in one of nodes.
 
 ### diff_node_subs()
 
-An example of the use of `diff_node_subs()` is shown in `#sample_4`.
+The function `diff_node_subs()` compares subscribe topic names of nodes of architectures.
 
 ```python
 #sample_4
 
-left_node = left_arch.nodes[0]
-right_node = right_arch.nodes[0]
+left_node = left_arch.get_node('node1')
+right_node = right_arch.get_node('node1')
 
-#get publish topic names that are only in old and new respectively.
-left_only_pub_topics, right_only_pub_topics = Architecture.diff_node_subs(left_node, right_node)
+#get subscribe topic names that are only in left_node and right_node respectively
+left_only_sub_topics, right_only_sub_topics = Architecture.diff_node_subs(left_node, right_node)
 
+#display differences
 print(left_only_sub_topics)
 print(right_only_sub_topics)
 
-#result
-#('topic1',)
-#('topic2',)
-
 ```
-In this case, consider a comparison for the first node (with index 0) of `left_arch` and `right_arch`. In this case, the setup assumes that the `left_node` has `topic1` as the subscribe topic and the `right_node` has `topic2` as the subscribe topic.
-At this time, there is no common subscribe topic for both.
-Therefore, the subscribe topic that exists only in the `left_node` is `topic1` and the subscribe topic that exists only in the `right_node` is `topic2`.
-Therefore, these are returned as the names of the subscribe topics that exist only in each node and are output at the end of the script.
+This function inputs two nodes of architectures, compares them, and outputs the subscribe topic names that exist only in one of nodes.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -22,5 +22,7 @@ In detail, the following sections are listed as below.
 - [**How to define inter-node data path**](./inter_node_data_path.md) section will tell you how to use `architecture.search_paths()`
 - [**How to define intra-node data path**](./intra_node_data_path.md) will let you know what `message_context` is. This is advanced topic than others
 - [**Practical example with CARET_demos**](./practical_example.md) will demonstrates configuration process on [`CARET_demos`](https://github.com/tier4/CARET_demos)
+- [**Require differences of two architectures**](./architecture_diff_func.md) will tell you how to use `diff_XXX_YYY()` functions
+
 
 **Visualization of application structure** will be prepared as an appendix which shows another usage of an architecture object. CARET can show structure of a targeted application while it is a performance analysis tool. This appendix will be disclosed in the near future also.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -24,4 +24,4 @@ In detail, the following sections are listed as below.
 - [**How to rename sub-objects**](./rename_function.md) section will tell you how to use `rename_XXX()`
 - [**How to get difference of two architectures**](./architecture_diff_func.md) will tell you how to use `diff_XXX_YYY()` functions
 - [**Practical example with CARET_demos**](./practical_example.md) will demonstrates configuration process on [`CARET_demos`](https://github.com/tier4/CARET_demos)
-**Visualization of application structure** will be prepared as an appendix which shows another usage of an architecture object. CARET can show structure of a targeted application while it is a performance analysis tool. This appendix will be disclosed in the near future also.
+  **Visualization of application structure** will be prepared as an appendix which shows another usage of an architecture object. CARET can show structure of a targeted application while it is a performance analysis tool. This appendix will be disclosed in the near future also.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -22,8 +22,6 @@ In detail, the following sections are listed as below.
 - [**How to define inter-node data path**](./inter_node_data_path.md) section will tell you how to use `architecture.search_paths()`
 - [**How to define intra-node data path**](./intra_node_data_path.md) will let you know what `message_context` is. This is advanced topic than others
 - [**How to rename sub-objects**](./rename_function.md) section will tell you how to use `rename_XXX()`
+- [**How to get difference of two architectures**](./architecture_diff_func.md) will tell you how to use `diff_XXX_YYY()` functions
 - [**Practical example with CARET_demos**](./practical_example.md) will demonstrates configuration process on [`CARET_demos`](https://github.com/tier4/CARET_demos)
-- [**Require differences of two architectures**](./architecture_diff_func.md) will tell you how to use `diff_XXX_YYY()` functions
-
-
 **Visualization of application structure** will be prepared as an appendix which shows another usage of an architecture object. CARET can show structure of a targeted application while it is a performance analysis tool. This appendix will be disclosed in the near future also.


### PR DESCRIPTION
## Description
`Require differences of two architectures` is added to chapter Configuration of CARET_doc.
`Require differences of two architectures` section explains how to use `diff_XXX_YYY` function.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
