### PR TITLE
docs: added docs for runtime tracepoints  er-diagram and its definition

### DIFF
--- a/docs/design/trace_points/runtime_trace_points.md
+++ b/docs/design/trace_points/runtime_trace_points.md
@@ -28,7 +28,14 @@ erDiagram
  uint64_t message_timestamp
  }
 
- dispatch_subscription_callback{
+ "rmw_take(after v0.4.10)"{
+ address rmw_subscription_handle
+ address message
+ uint64_t source_timestamp
+ bool taken
+ }
+
+ "dispatch_subscription_callback(before v0.4.9)"{
  address message
  address callback
  uint64_t source_timestamp
@@ -66,11 +73,13 @@ erDiagram
     rcl_publish ||--|| dds_write: message_addr
     dds_write ||--|| dds_bind_addr_to_stamp: message_addr
 
-    dds_bind_addr_to_stamp ||--|| dispatch_subscription_callback: source_timestamp
+    dds_bind_addr_to_stamp ||--|| "dispatch_subscription_callback(before v0.4.9)": source_timestamp
 
-
+    dds_bind_addr_to_stamp ||--|| "rmw_take(after v0.4.10)": source_timestamp
+    "rmw_take(after v0.4.10)" ||--|| callback_start: tid
     dispatch_intra_process_subscription_callback ||--|| callback_start: callback
-    dispatch_subscription_callback ||--|| callback_start: callback
+    "dispatch_subscription_callback(before v0.4.9)" ||--|| callback_start: callback
+
     callback_start ||--|| callback_end: callback
 
 ```
@@ -126,7 +135,7 @@ Sampled items
 
 ---
 
-#### ros2:dispatch_subscription_callback
+#### ros2:dispatch_subscription_callback (before v0.4.9)
 
 [Extended tracepoints]
 
@@ -136,6 +145,21 @@ Sampled items
 - void \* callback
 - uint64_t source_timestamp
 - uint64_t message_timestamp
+
+This tracepoint was **deprecated** in v0.4.10.
+
+---
+
+#### ros2:rmw_take (after v0.4.10)
+
+[Built-in tracepoints]
+
+Sampled items
+
+- void \* rmw_subscription_handle
+- void \* message
+- int64_t \* source_timestamp
+- bool \* taken
 
 ---
 

--- a/docs/design/trace_points/runtime_trace_points.md
+++ b/docs/design/trace_points/runtime_trace_points.md
@@ -161,7 +161,7 @@ Sampled items
 - int64_t \* source_timestamp
 - bool \* taken
 
-In CARET, This tracepoint is used to correctly link the `callback_start` to the `rclcpp_publish` that triggered the callback..
+In CARET, This tracepoint is used to correctly link the `callback_start` to the `rclcpp_publish` that triggered the callback.
 Until version 0.4.9, ros2:dispatch_subscription_callback was used to link `rclcpp_publish` and `callback_start` events.
 
 ---

--- a/docs/design/trace_points/runtime_trace_points.md
+++ b/docs/design/trace_points/runtime_trace_points.md
@@ -161,7 +161,7 @@ Sampled items
 - int64_t \* source_timestamp
 - bool \* taken
 
-In CARET, This tracepoint is used to correctly link `callback_start` to the `rclcpp_publish` that triggered the callback..
+In CARET, This tracepoint is used to correctly link the `callback_start` to the `rclcpp_publish` that triggered the callback..
 Until version 0.4.9, ros2:dispatch_subscription_callback was used to link `rclcpp_publish` and `callback_start` events.
 
 ---

--- a/docs/design/trace_points/runtime_trace_points.md
+++ b/docs/design/trace_points/runtime_trace_points.md
@@ -161,8 +161,8 @@ Sampled items
 - int64_t \* source_timestamp
 - bool \* taken
 
-In CARET, this tracepoint is used to determine the `callback_start` corresponding to the `rclcpp_publish`.
-Until version 0.4.9, ros2:dispatch_subscription_callback was used to link rclcpp_publish and callback_start events.
+In CARET, This tracepoint is used to correctly link `callback_start` to the `rclcpp_publish` that triggered the callback..
+Until version 0.4.9, ros2:dispatch_subscription_callback was used to link `rclcpp_publish` and `callback_start` events.
 
 ---
 

--- a/docs/design/trace_points/runtime_trace_points.md
+++ b/docs/design/trace_points/runtime_trace_points.md
@@ -28,14 +28,14 @@ erDiagram
  uint64_t message_timestamp
  }
 
- "rmw_take(after v0.4.10)"{
+ rmw_take{
  address rmw_subscription_handle
  address message
  uint64_t source_timestamp
  bool taken
  }
 
- "dispatch_subscription_callback(before v0.4.9)"{
+ dispatch_subscription_callback{
  address message
  address callback
  uint64_t source_timestamp
@@ -73,12 +73,12 @@ erDiagram
     rcl_publish ||--|| dds_write: message_addr
     dds_write ||--|| dds_bind_addr_to_stamp: message_addr
 
-    dds_bind_addr_to_stamp ||--|| "dispatch_subscription_callback(before v0.4.9)": source_timestamp
+    dds_bind_addr_to_stamp ||--|| dispatch_subscription_callback: source_timestamp
 
-    dds_bind_addr_to_stamp ||--|| "rmw_take(after v0.4.10)": source_timestamp
-    "rmw_take(after v0.4.10)" ||--|| callback_start: tid
+    dds_bind_addr_to_stamp ||--|| rmw_take: source_timestamp
+    rmw_take ||--|| callback_start: tid
     dispatch_intra_process_subscription_callback ||--|| callback_start: callback
-    "dispatch_subscription_callback(before v0.4.9)" ||--|| callback_start: callback
+    dispatch_subscription_callback ||--|| callback_start: callback
 
     callback_start ||--|| callback_end: callback
 
@@ -146,7 +146,7 @@ Sampled items
 - uint64_t source_timestamp
 - uint64_t message_timestamp
 
-This tracepoint was **deprecated** in v0.4.10.
+This trace point is no longer used since v0.4.10.
 
 ---
 
@@ -160,6 +160,9 @@ Sampled items
 - void \* message
 - int64_t \* source_timestamp
 - bool \* taken
+
+In CARET, this trace point is used to determine the callback_start event corresponding to the rclcpp_publish event.
+Until version 0.4.9, ros2:dispatch_subscription_callback was used to link rclcpp_publish and callback_start events.
 
 ---
 

--- a/docs/design/trace_points/runtime_trace_points.md
+++ b/docs/design/trace_points/runtime_trace_points.md
@@ -161,7 +161,7 @@ Sampled items
 - int64_t \* source_timestamp
 - bool \* taken
 
-In CARET, This tracepoint is used to correctly link the `callback_start` to the `rclcpp_publish` that triggered the callback.
+In CARET, this tracepoint is used to correctly link the `callback_start` to the `rclcpp_publish` that triggered the callback.
 Until version 0.4.9, ros2:dispatch_subscription_callback was used to link `rclcpp_publish` and `callback_start` events.
 
 ---

--- a/docs/design/trace_points/runtime_trace_points.md
+++ b/docs/design/trace_points/runtime_trace_points.md
@@ -146,7 +146,7 @@ Sampled items
 - uint64_t source_timestamp
 - uint64_t message_timestamp
 
-This trace point is no longer used since v0.4.10.
+This tracepoint is no longer used from v0.4.10 onwards.
 
 ---
 
@@ -161,7 +161,7 @@ Sampled items
 - int64_t \* source_timestamp
 - bool \* taken
 
-In CARET, this trace point is used to determine the callback_start event corresponding to the rclcpp_publish event.
+In CARET, this tracepoint is used to determine the `callback_start` corresponding to the `rclcpp_publish`.
 Until version 0.4.9, ros2:dispatch_subscription_callback was used to link rclcpp_publish and callback_start events.
 
 ---


### PR DESCRIPTION
## Description
After CARET v4.10, records are merged using the tracepoint `rmw_take`, added in humble. With this change, the `dispatch_subscription_callback trace` point is no longer a critical event in record merge.
<!-- Write a brief description of this PR. -->

## Related links
- https://github.com/tier4/CARET_trace/pull/113
- https://github.com/tier4/CARET_analyze/pull/296
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

















































































