### PR TITLE
fix(recording): add tracepoint for light record

### DIFF
--- a/docs/recording/recording.md
+++ b/docs/recording/recording.md
@@ -181,6 +181,7 @@ def generate_launch_description():
             "ros2:rclcpp*" ,
             "ros2_caret:rclcpp*" ,
             "ros2_caret:rmw*",
+            "ros2:rmw_take",
             "*callback_group*",
             "ros2_caret:*executor",
             "ros2_caret:dds_bind*",


### PR DESCRIPTION
## Description

- `ros2:dispatch_subscription_callback` trace point is replaced with `ros2:rmw_take` by https://github.com/tier4/CARET_trace/pull/113.
- This PR adds `ros2:rmw_take` to light option filter

## Related links

https://tier4.atlassian.net/browse/RT2-725
https://github.com/tier4/CARET_trace/pull/113
https://github.com/tier4/ros2caret/pull/70
https://github.com/tier4/caret_autoware_launch/pull/5

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
