### PR TITLE
fix(recording): update trace filter

### DIFF
--- a/docs/recording/trace_filtering.md
+++ b/docs/recording/trace_filtering.md
@@ -34,25 +34,27 @@ It will be handy to prepare a trace filter setting file like the following.
 
 export CARET_IGNORE_NODES=\
 "\
-/rviz*\
+/rviz*:\
+/care_trace_*:\
 "
 
 export CARET_IGNORE_TOPICS=\
 "\
 /clock:\
-/parameter_events\
+/parameter_events:\
 "
 
 # if you want to select nodes or topics,
 # please remove comment out of the followings.
 # export CARET_SELECT_NODES=\
 # "\
-# /rviz*\
+# /rviz*:\
+# /care_trace_*:\
 # "
 
 # export CARET_SELECT_TOPICS=\
 # "\
 # /clock:\
-# /parameter_events\
+# /parameter_events:\
 # "
 ```

--- a/docs/recording/trace_filtering.md
+++ b/docs/recording/trace_filtering.md
@@ -35,7 +35,7 @@ It will be handy to prepare a trace filter setting file like the following.
 export CARET_IGNORE_NODES=\
 "\
 /rviz*:\
-/care_trace_*:\
+/caret_trace_*:\
 "
 
 export CARET_IGNORE_TOPICS=\
@@ -49,7 +49,7 @@ export CARET_IGNORE_TOPICS=\
 # export CARET_SELECT_NODES=\
 # "\
 # /rviz*:\
-# /care_trace_*:\
+# /caret_trace_*:\
 # "
 
 # export CARET_SELECT_TOPICS=\


### PR DESCRIPTION
## Description

Runtime recording function creates a new node named `caret_trace_*` for each process. It sometimes causes duplicated id warning, and there is no need to trace `caret_trace_*`

## Related links

https://tier4.atlassian.net/browse/RT2-599
https://github.com/tier4/CARET_trace/pull/68
https://star4.slack.com/archives/C017YM4AA06/p1673595959892529

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
