### PR TITLE
docs(changelog): update changelog for tag v0.4.16.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 ## CARET
 
+### v0.4.16.1 <small>\_ Sep 21, 2023</small> {id = "0.4.16.1"}
+
+- **Fix**: Fixed an issue that prevented CARETmeasurement when using cyclonedds 0.10.x. ([caret #121](https://github.com/tier4/caret/pull/121))
+- **New**: Added API to plot the response time of Paths as timeseries. ([CARET_analyze #322](https://github.com/tier4/CARET_analyze/pull/322))
+- Changed to temporarily specify the version of `setuptools` to be installed, as the latest `setuptools` causes error during CARET building. ([CARET_analyze #330](https://github.com/tier4/CARET_analyze/pull/330))
+
 ### v0.4.15 <small>\_ Sep 4, 2023</small> {id = "0.4.15"}
 
 - Updated the version of humble branch in tier4/rclcpp repository, which is forked from ros2/rclcpp, from 16.0.1 to 16.0.5. ([rclcpp #4](https://github.com/tier4/rclcpp/pull/4))


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR is the made for the changelog update for CARET v0.4.16.1.
I intentionally skipped tag v0.4.16 because there was a bug where cyclonedds were not imported correctly when building CARET.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
