### PR TITLE
docs: add warning for sim_time support of response time

### DIFF
--- a/docs/recording/sim_time.md
+++ b/docs/recording/sim_time.md
@@ -80,6 +80,11 @@ In case `/clock` topic is not recorded in trace data, the following error will o
 InvalidArgumentError: Failed to load sim_time. Please measure again with clock_recorder running.
 ```
 
+<prettier-ignore-start>
+!!!warning
+    If the timer callback exists in middle of the target path, ROSBAG playback rate signifficantly affects the behavior of the path. As a result, even when `xaxis_type` is `'sim_time'`, [response time](../visualization/path/response_time.md) of the path cannot be calculated correctly for the trace data whose ROSBAG playback rate is not 1.0.
+<prettier-ignore-end>
+
 ## Sample to use sim_time
 
 Explanation below assumes CARET is installed to `~/ros2_caret_ws` and the sample application used in the tutorial section is located in `~/ros2_ws`.


### PR DESCRIPTION
## Description

Added the warning about the potential error of response time calculation when analyzing trace data recorded under ROSBAG playback.

## Related links
https://tier4.atlassian.net/browse/RT2-1177

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
