### PR TITLE
fix: apply remove old API of response time histogram

### DIFF
--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -69,10 +69,6 @@ If you find what you are interested in, please access to a link embedded in a he
 
 ![message_flow](./imgs/message_flow_sample.png)
 
-### [Response Time Histogram](./visualization/path/response_time.md)
-
-![Response_Time_Histogram](./imgs/response_time_default_histogram.png)
-
 ### [Chain latency](./visualization/path/chain_latency.md)
 
 ![chain_latency_sample](./imgs/chain_latency_sample.png)


### PR DESCRIPTION
## Description
remove graph of old function (Response Time Histogram) in Gallery.

<!-- Write a brief description of this PR. -->

## Related links
Jira: https://tier4.atlassian.net/browse/RT2-1307

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
