### PR TITLE
fix: add restrictions on iron

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -208,4 +208,3 @@ Please make sure to source local_setup.bash of this workspace before you run Rel
 !!! Note
     The iron version of caret does not support RelayNode analysis because it does not add trace points for Generic communication.
 <prettier-ignore-end>
-

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -203,3 +203,9 @@ pip3 install -U numexpr bottleneck matplotlib
    ```
 
 Please make sure to source local_setup.bash of this workspace before you run RelayNode.
+
+<prettier-ignore-start>
+!!! Note
+    The iron version of caret does not support RelayNode analysis because it does not add trace points for Generic communication.
+<prettier-ignore-end>
+


### PR DESCRIPTION
## Description

Note that RelayNode analysis is not possible with iron.

## Related links

[https://tier4.atlassian.net/browse/RT2-2362](https://tier4.atlassian.net/browse/RT2-2362)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
