### PR TITLE
docs(known_issue): add extra workarounds for library confliction

### DIFF
--- a/docs/faq/known_issues.md
+++ b/docs/faq/known_issues.md
@@ -63,13 +63,33 @@ export PYTHONWARNINGS=ignore:"setup.py install is deprecated.",ignore:"easy_inst
 - Cause
   - `~/ros2_caret_ws/install/tracetools/lib/libtracetools.so` needs to be linked, but `/opt/ros/humble/lib/libtracetools.so` is referred when using some packages
   - For instance, `pcl_ros` package has `/opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake` which enforces `/opt/ros/humble/lib/libtracetools.so` to be linked
-- Workaround
+- Workaround 1
   - Remove `/opt/ros/humble/lib/libtracetools.so;` from `/opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake`
 
 ```sh
 sudo cp /opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake /opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake.bak
 sudo sed -i -e 's/\/opt\/ros\/humble\/lib\/libtracetools.so;//g' /opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake
 ```
+
+- Workaround 2
+  - If the error persists after applying workaround 1, modify all libraries
+
+```sh
+sudo grep -rl '/opt/ros/humble/lib/libtracetools.so;' /opt/ros/humble/share --include="*.cmake" |
+    while read -r f; do
+        echo "Delete reference to libtracetools from $f"
+        sudo cp "$f" "$f.bak"
+        sudo sed -i 's|/opt/ros/humble/lib/libtracetools.so;||g' "$f"
+    done
+```
+
+- Workaround 3
+  - If the error persists even after applying workaround 1 and 2, ensure that the CARET tracetools library is used by explicitly setting `-Dtracetools_DIR`
+
+```sh
+--cmake-args -Dtracetools_DIR="$HOME/ros2_caret_ws/install/tracetools/share/tracetools/cmake"
+```
+
 
 ### Build using ament_cmake
 
@@ -103,12 +123,31 @@ sudo sed -i -e 's/SYSTEM//g' ament_auto_add_library.cmake
 - Cause
   - To build with CARET, caret/rclcpp should be used. However, in case rclcpp in SYSTEM ( `/opt/ros/humble` ) is used for some reasons, build will fail
   - Take `pcl_ros` for example, `/opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake` enforces `/opt/ros/humble/include/rclcpp` to be referred. So that caret/rclcpp is not used and building a package depending on `pcl_ros` will fail
-- Workaround
+- Workaround 1
   - Remove `/opt/ros/humble/include/rclcpp;` from `/opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake`
 
 ```sh
 sudo cp /opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake /opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake.bak2
 sudo sed -i -e 's/\/opt\/ros\/humble\/include\/rclcpp;//g' /opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake
+```
+
+- Workaround 2
+  - If the error persists after applying workaround 1, modify all libraries
+
+```sh
+sudo grep -rl '/opt/ros/humble/include/rclcpp;' /opt/ros/humble/share --include="*.cmake" |
+    while read -r f; do
+        echo "Delete reference to rclcpp from $f"
+        sudo cp "$f" "$f.bak"
+        sudo sed -i 's|/opt/ros/humble/include/rclcpp;||g' "$f"
+    done
+```
+
+- Workaround 3
+  - If the error persists even after applying workaround 1 and 2, ensure that the CARET rclcpp is used by explicitly setting `-Drclcpp_DIR`
+
+```sh
+--cmake-args -Drclcpp_DIR="$HOME/ros2_caret_ws/install/rclcpp/share/rclcpp/cmake"
 ```
 
 ## Recording

--- a/docs/faq/known_issues.md
+++ b/docs/faq/known_issues.md
@@ -1,3 +1,5 @@
+<!-- cspell:ignore Drclcpp Dtracetools -->
+
 # Known issues
 
 ## Install

--- a/docs/faq/known_issues.md
+++ b/docs/faq/known_issues.md
@@ -87,6 +87,7 @@ sudo grep -rl '/opt/ros/humble/lib/libtracetools.so;' /opt/ros/humble/share --in
 
 - Workaround 3
   - If the error persists even after applying workaround 1 and 2, ensure that the CARET tracetools library is used by explicitly setting `-Dtracetools_DIR`
+  - This can occur especially when the target application is built with `--merge-install`
 
 ```sh
 --cmake-args -Dtracetools_DIR="$HOME/ros2_caret_ws/install/tracetools/share/tracetools/cmake"
@@ -128,6 +129,7 @@ sudo grep -rl '/opt/ros/humble/include/rclcpp;' /opt/ros/humble/share --include=
 
 - Workaround 3
   - If the error persists even after applying workaround 1 and 2, ensure that the CARET rclcpp is used by explicitly setting `-Drclcpp_DIR`
+  - This can occur especially when the target application is built with `--merge-install`
 
 ```sh
 --cmake-args -Drclcpp_DIR="$HOME/ros2_caret_ws/install/rclcpp/share/rclcpp/cmake"

--- a/docs/faq/known_issues.md
+++ b/docs/faq/known_issues.md
@@ -90,25 +90,6 @@ sudo grep -rl '/opt/ros/humble/lib/libtracetools.so;' /opt/ros/humble/share --in
 --cmake-args -Dtracetools_DIR="$HOME/ros2_caret_ws/install/tracetools/share/tracetools/cmake"
 ```
 
-
-### Build using ament_cmake
-
-- Issue
-  - The following error happens when building a target application using ament_cmake
-    - `error: too few arguments to function ‘void ros_trace_rclcpp_publish`
-- Cause
-  - `SYSTEM` is added as dependencies in ament_cmake_auto by [this PR](https://github.com/ament/ament_cmake/commit/799183ab9bcfd9b66df0de9b644abaf8c9b78e84). As a result, ros2/rclcpp is used rather than CARET/rclcpp in some packages
-- Workaround
-  - Remove `SYSTEM` from dependencies in ament_cmake_auto
-
-```sh
-cd /opt/ros/humble/share/ament_cmake_auto/cmake/
-sudo cp ament_auto_add_executable.cmake ament_auto_add_executable.cmake.bak
-sudo cp ament_auto_add_library.cmake ament_auto_add_library.cmake.bak
-sudo sed -i -e 's/SYSTEM//g' ament_auto_add_executable.cmake
-sudo sed -i -e 's/SYSTEM//g' ament_auto_add_library.cmake
-```
-
 ### SYSTEM's rclcpp is referred
 
 - Issue
@@ -148,6 +129,24 @@ sudo grep -rl '/opt/ros/humble/include/rclcpp;' /opt/ros/humble/share --include=
 
 ```sh
 --cmake-args -Drclcpp_DIR="$HOME/ros2_caret_ws/install/rclcpp/share/rclcpp/cmake"
+```
+
+### Build using ament_cmake
+
+- Issue
+  - The following error happens when building a target application using ament_cmake
+    - `error: too few arguments to function ‘void ros_trace_rclcpp_publish`
+- Cause
+  - `SYSTEM` is added as dependencies in ament_cmake_auto by [this PR](https://github.com/ament/ament_cmake/commit/799183ab9bcfd9b66df0de9b644abaf8c9b78e84). As a result, ros2/rclcpp is used rather than CARET/rclcpp in some packages
+- Workaround
+  - Remove `SYSTEM` from dependencies in ament_cmake_auto
+
+```sh
+cd /opt/ros/humble/share/ament_cmake_auto/cmake/
+sudo cp ament_auto_add_executable.cmake ament_auto_add_executable.cmake.bak
+sudo cp ament_auto_add_library.cmake ament_auto_add_library.cmake.bak
+sudo sed -i -e 's/SYSTEM//g' ament_auto_add_executable.cmake
+sudo sed -i -e 's/SYSTEM//g' ament_auto_add_library.cmake
 ```
 
 ## Recording


### PR DESCRIPTION
## Description

- When building the target application using `--merge-install`, a build error may occur
- This PR adds workarounds for this case

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-39289)

## Notes for reviewers

- Adding `Drclcpp` and `Dtracetools` to cspell ignore dictionary was refused, so I use inline ignores
  - https://github.com/tier4/autoware-spell-check-dict/pull/860#issuecomment-3273423624

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
