### PR TITLE
fix: security update mkdocs, Markdown and pygments

### DIFF
--- a/deploy-docs/mkdocs-requirements.txt
+++ b/deploy-docs/mkdocs-requirements.txt
@@ -1,7 +1,6 @@
-fontawesome_markdown
-markdown==3.3.7
+markdown~=3.8.1
 mdx_truly_sane_lists
-mkdocs==1.4.3
+mkdocs~=1.6.0
 mkdocs-awesome-pages-plugin==2.9.1
 mkdocs-exclude
 mkdocs-macros-plugin
@@ -15,4 +14,4 @@ pymdown-extensions
 python-markdown-math
 tabulate
 # cspell:ignore pygments
-pygments==2.18.0
+pygments~=2.20.0

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -63,7 +63,9 @@ markdown_extensions:
   - attr_list
   - codehilite:
       guess_lang: false
-  - fontawesome_markdown
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - footnotes
   - mdx_math
   - mdx_truly_sane_lists:


### PR DESCRIPTION
## Description

This PR updates dependency versions for security compliance and ensures compatibility with the latest build environment.

- Updated mkdocs, markdown, and pygments to meet security requirements.
- Upgraded mkdocs to >=1.6.0 to resolve dependency conflicts with newer markdown versions.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
